### PR TITLE
[Frontend] Clean up driver code, add globals

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -30,6 +30,7 @@ dependencies:
 - criterion-measurement
 - mtl
 - prettyprinter
+- silently
 - text
 - transformers
 

--- a/src/TeenyTT/Core/Compute.hs
+++ b/src/TeenyTT/Core/Compute.hs
@@ -48,5 +48,4 @@ getGlobal lvl = liftCompute $ Compute $ asks (Env.level lvl)
 
 emit :: (MonadCompute m) => Doc ann -> m ()
 emit doc = liftCompute $ Compute $ liftIO $ do
-    putDoc doc
-    putStrLn ""
+    putDocLn doc

--- a/src/TeenyTT/Core/Pretty.hs
+++ b/src/TeenyTT/Core/Pretty.hs
@@ -1,8 +1,11 @@
 module TeenyTT.Core.Pretty
   ( module Pp
-  , putDoc
   , Debug(..)
+  -- * IO
+  , putDocLn
   ) where
+
+import Control.Monad.IO.Class
 
 import Prettyprinter as Pp
 import Prettyprinter.Render.Text as Render
@@ -18,3 +21,11 @@ instance (Debug a, Debug b) => Debug (a, b) where
 
 -- [FIXME: Reed M, 06/11/2021] Fill in this class
 class Display a where
+
+--------------------------------------------------------------------------------
+-- IO
+
+putDocLn :: (MonadIO m) => Doc ann -> m ()
+putDocLn doc = liftIO $ do
+    putDoc doc
+    putStrLn ""

--- a/src/TeenyTT/Frontend/Driver/Debug.hs
+++ b/src/TeenyTT/Frontend/Driver/Debug.hs
@@ -1,0 +1,3 @@
+module TeenyTT.Frontend.Driver.Debug
+  (
+  ) where

--- a/src/TeenyTT/Frontend/Driver/Monad.hs
+++ b/src/TeenyTT/Frontend/Driver/Monad.hs
@@ -1,0 +1,113 @@
+module TeenyTT.Frontend.Driver.Monad
+  ( Driver
+  , runDriver
+  , liftRM
+  , hoistError
+  -- * State Management
+  , sandbox
+  -- * Annotations
+  , annotateTp
+  , getAnnotation
+  -- * Globals
+  , getGlobals
+  , getGlobal
+  , bindGlobal
+  -- * Output
+  , divider
+  , debugPrint
+  ) where
+
+import Control.Monad.State.Strict
+
+import Data.Foldable
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+
+import TeenyTT.Core.Ident
+import TeenyTT.Core.Pretty
+import TeenyTT.Core.Env (Env, Index, Level)
+import TeenyTT.Core.Env qualified as Env
+
+import TeenyTT.Core.Refiner.Monad (RM)
+import TeenyTT.Core.Refiner.Monad qualified as RM
+
+import TeenyTT.Core.Domain qualified as D
+import TeenyTT.Core.Syntax qualified as S
+
+newtype Driver a = Driver { unDriver :: StateT DriverState IO a }
+    deriving (Functor, Applicative, Monad, MonadState DriverState, MonadIO)
+
+-- [TODO: Reed M, 07/11/2021] Thread the handle down into the refiner.
+
+-- [FIXME: Reed M, 07/11/2021] The globals uses a bad data structure. I should
+-- split the bindings + name resolution up
+data DriverState = DriverState
+    { globals  :: Env (Cell (D.Value, D.Type))
+    , typeAnns :: Map Ident D.Type
+    }
+
+initState :: DriverState
+initState = DriverState
+    { globals = mempty
+    , typeAnns = mempty
+    }
+
+runDriver :: Driver a -> IO a
+runDriver m = evalStateT (unDriver m) initState
+
+-- [FIXME: Reed M, 06/11/2021] This should use proper pretty printing
+hoistError :: (Show err) => Either err a -> Driver a
+hoistError (Left err) = liftIO $ fail $ show err
+hoistError (Right a) = pure a
+
+liftRM :: RM a -> Driver a
+liftRM m = do
+    glbs <- getGlobals
+    res <- liftIO $ RM.runRM glbs m
+    hoistError res
+
+--------------------------------------------------------------------------------
+-- State Mangement
+
+-- | 'sandbox' takes a 'Driver' action, and captures it's state.
+-- This is particularly useful for benchmarking.
+sandbox :: Driver a -> Driver (() -> IO a)
+sandbox m = do
+    s <- get
+    pure $ \_ -> evalStateT (unDriver m) s
+
+--------------------------------------------------------------------------------
+-- Type Annotations
+
+-- | Add a type annotation to a top-level identifier.
+annotateTp :: Ident -> D.Type -> Driver ()
+annotateTp x tp =
+    modify' (\st -> st { typeAnns = Map.insert x tp (typeAnns st) })
+
+getAnnotation :: Ident -> Driver (Maybe D.Type)
+getAnnotation x =
+    gets (Map.lookup x . typeAnns)
+
+--------------------------------------------------------------------------------
+-- Globals
+
+getGlobals :: Driver (Env (Cell (D.Value, D.Type)))
+getGlobals = gets globals
+
+getGlobal :: Ident -> Driver (Maybe (D.Value, D.Type))
+getGlobal x =
+    gets (fmap contents . find (\Cell{..} -> ident == x) . globals)
+
+bindGlobal :: Ident -> D.Value -> D.Type -> Driver ()
+bindGlobal x val tp =
+    modify' (\s -> s { globals = Env.extend (globals s) (Cell x (val, tp)) })
+
+--------------------------------------------------------------------------------
+-- Output
+
+divider :: Driver ()
+divider = liftIO $ putStrLn (replicate 80 '-')
+
+debugPrint :: (Debug a) => a -> Driver ()
+debugPrint a = liftIO $ do
+    putDocLn $ dump a

--- a/teenytt.cabal
+++ b/teenytt.cabal
@@ -52,6 +52,8 @@ library
       TeenyTT.Core.TermBuilder
       TeenyTT.Frontend.ConcreteSyntax
       TeenyTT.Frontend.Driver
+      TeenyTT.Frontend.Driver.Debug
+      TeenyTT.Frontend.Driver.Monad
       TeenyTT.Frontend.Elaborator
       TeenyTT.Frontend.Parser
       TeenyTT.Frontend.Parser.Grammar
@@ -76,6 +78,7 @@ library
     , deepseq
     , mtl
     , prettyprinter
+    , silently
     , text
     , transformers
   default-language: Haskell2010
@@ -98,6 +101,7 @@ executable teenytt-exe
     , mtl
     , optparse-applicative
     , prettyprinter
+    , silently
     , teenytt
     , text
     , transformers
@@ -121,6 +125,7 @@ test-suite teenytt-test
     , deepseq
     , mtl
     , prettyprinter
+    , silently
     , teenytt
     , text
     , transformers


### PR DESCRIPTION
## Patch Description

This PR cleans up the driver code, and actually adds global variables to the driver state.

## Notes
I should probably switch back to IORefs at some point, but this works for now.